### PR TITLE
Fix notFound/deactivated format and comments according to README

### DIFF
--- a/tests/10-bindings.js
+++ b/tests/10-bindings.js
@@ -34,8 +34,8 @@ describe('10.1 HTTP(S) Binding', function() {
     const endpoint = didResolver.endpoint;
     const validDids = didResolver.supportedDids.valid;
     // These fields are optional in the implementation config
-    const deactivatedDid = didResolver.supportedDids.deactivated || null;
-    const notFoundDid = didResolver.supportedDids.notFound || null;
+    const deactivatedDids = didResolver.supportedDids.deactivated || [];
+    const notFoundDids = didResolver.supportedDids.notFound || [];
     // derefUrls: [{didUrl, dereferencingOptions}] for DID URL
     // dereferencing tests
     const derefUrls = didResolver.supportedDids.derefUrls || [];
@@ -224,11 +224,13 @@ describe('10.1 HTTP(S) Binding', function() {
 
       // Normative: "NOT_FOUND → 404"
       // Requires notFound DID to be set in the implementation config
-      if(notFoundDid) {
+      notFoundDids.forEach(({did, resolutionOptions}) => {
+        const baseUrl = `${endpoint}/${did}`;
+        const url = addQueryParametersToUrl(baseUrl, resolutionOptions);
+
         it('NOT_FOUND error MUST map to HTTP status 404', async function() {
           this.test.link =
             'https://w3c.github.io/did-resolution/#bindings-https';
-          const url = `${endpoint}/${notFoundDid}`;
           const rv = await fetch(url, {
             headers: {Accept: DID_RESOLUTION_MEDIA_TYPE}
           });
@@ -237,7 +239,7 @@ describe('10.1 HTTP(S) Binding', function() {
           checkErrorResolutionResult(resolutionResult,
             'https://www.w3.org/ns/did#NOT_FOUND');
         });
-      }
+      });
 
       // Normative: "REPRESENTATION_NOT_SUPPORTED → 406"
       it('REPRESENTATION_NOT_SUPPORTED error MUST map to HTTP ' +
@@ -265,18 +267,20 @@ describe('10.1 HTTP(S) Binding', function() {
       //   returns a deactivated metadata property with the value true …
       //   The HTTP response status code MUST be 410"
       // Requires deactivated DID to be set in the implementation config
-      if(deactivatedDid) {
+      deactivatedDids.forEach(({did, resolutionOptions}) => {
+        const baseUrl = `${endpoint}/${did}`;
+        const url = addQueryParametersToUrl(baseUrl, resolutionOptions);
+
         it('If deactivated metadata property is true, ' +
           'HTTP response status MUST be 410', async function() {
           this.test.link =
             'https://w3c.github.io/did-resolution/#bindings-https';
-          const url = `${endpoint}/${deactivatedDid}`;
           const rv = await fetch(url, {
             headers: {Accept: DID_RESOLUTION_MEDIA_TYPE}
           });
           rv.status.should.equal(410);
         });
-      }
+      });
 
       // --- DID URL Dereferencing binding ---
       // Tests below run only when the implementation config provides

--- a/tests/10-bindings.js
+++ b/tests/10-bindings.js
@@ -223,7 +223,8 @@ describe('10.1 HTTP(S) Binding', function() {
       });
 
       // Normative: "NOT_FOUND → 404"
-      // Requires notFound DID to be set in the implementation config
+      // Requires one or more notFoundDids to be set in the implementation
+      // config, each as an object: {did, resolutionOptions}
       notFoundDids.forEach(({did, resolutionOptions}) => {
         const baseUrl = `${endpoint}/${did}`;
         const url = addQueryParametersToUrl(baseUrl, resolutionOptions);
@@ -266,7 +267,8 @@ describe('10.1 HTTP(S) Binding', function() {
       // Normative: "If the DID resolution or DID URL dereferencing function
       //   returns a deactivated metadata property with the value true …
       //   The HTTP response status code MUST be 410"
-      // Requires deactivated DID to be set in the implementation config
+      // Requires deactivatedDids: [{did, resolutionOptions}] in the
+      // implementation config
       deactivatedDids.forEach(({did, resolutionOptions}) => {
         const baseUrl = `${endpoint}/${did}`;
         const url = addQueryParametersToUrl(baseUrl, resolutionOptions);


### PR DESCRIPTION
This pull request refactors the HTTP(S) binding tests in `tests/10-bindings.js` to support multiple deactivated and not-found DIDs, improving test coverage and flexibility. The changes replace single-DID checks with iteration over arrays of DIDs, allowing for more comprehensive testing of error mapping and response codes.

Expanded error scenario testing:

* Updated the test setup to use arrays (`deactivatedDids` and `notFoundDids`) instead of single values, enabling the testing of multiple DIDs for deactivation and not-found scenarios.
* Refactored the NOT_FOUND error mapping test to iterate over all provided `notFoundDids`, ensuring each scenario is tested and mapped to HTTP status 404. [[1]](diffhunk://#diff-746a08a8c441c7005724f57b4b5c276557b71d7f8d88ef9858698a41079b0b08L226-L231) [[2]](diffhunk://#diff-746a08a8c441c7005724f57b4b5c276557b71d7f8d88ef9858698a41079b0b08L240-R243)
* Refactored the deactivated DID test to iterate over all provided `deactivatedDids`, verifying that each results in HTTP status 410.